### PR TITLE
Added route for CWTV to work

### DIFF
--- a/config.json
+++ b/config.json
@@ -1540,6 +1540,18 @@
       ],
       "catchall":false,
       "enabled":true
+    },
+    {
+      "name":"hlsioscwtv-warnerbros-com",
+      "dest_addr":"hlsioscwtv.warnerbros.com",
+      "modes":[
+        {
+          "port":80,
+          "mode":"http"
+        }
+      ],
+      "catchall":false,
+      "enabled":true
     }
   ]
 }


### PR DESCRIPTION
Noticed CW wasn't working anymore, looks like this new hlsioscwtv subdomain needs to also be proxied.
